### PR TITLE
ConnectionPool-Nutzung

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
 

--- a/Discord-Bot/pom.xml
+++ b/Discord-Bot/pom.xml
@@ -87,9 +87,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>3.0.0-M5</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <version>2.8.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/Discord-Bot/src/main/java/DiscordBot.java
+++ b/Discord-Bot/src/main/java/DiscordBot.java
@@ -55,7 +55,7 @@ public class DiscordBot {
     private List<GuildData> guildsData = new ArrayList<>();
     private String[] defIds;
     private long muteBanTimerPeriod = 5 * 60 * 1000;
-	private VoteDatabase voteDatabase;
+    private VoteDatabase voteDatabase;
     private RoleDatabase roleDatabase;
     private ChannelDatabase channelDatabase;
     private UserRecordsDatabase userRecordsDatabase;
@@ -97,17 +97,22 @@ public class DiscordBot {
         }
 
         LiteSQL.connect();
-        SQLManager.onCreate();
-
         LiteSQLActivity.connect();
-        ActivitySQLManager.onCreate();
+        if (!SQLManager.onCreate() || !ActivitySQLManager.onCreate()) {
+            System.out.println("-------------------- ERROR --------------------");
+            System.out.println(" Datenbank konnte nicht initialisiert werden!");
+            System.out.println(" Stoppe Bot...");
+            System.out.println("-----------------------------------------------");
+            System.exit(-1);
+        }
+
         new EventAudit().updateIgnoredChannels();
 
         JDABuilder builder = JDABuilder.createDefault(botToken);
         builder.enableIntents(GatewayIntent.GUILD_PRESENCES);
         builder.enableIntents(GatewayIntent.GUILD_MEMBERS);
         builder.setMemberCachePolicy(MemberCachePolicy.ALL);
-        
+
         builder.setToken(botToken);
 
         // Bot activity
@@ -286,17 +291,34 @@ public class DiscordBot {
     public String getAutoListenerFilePath() {
         return autoListenerFilePath;
     }
+
     public String getDbFilePath() {
         return dbFilePath;
     }
+
     public String getLogFilePath() {
         return logFilePath;
     }
-    public String getDiagramFilePath() {return diagramFilePath;}
-    public String getBotPbPath() {return botPbPath;}
-    public String getPbFilterPath() {return pbFilterPath;}
-    public String getPbPath() {return pbPath;}
-    public String getNewPbPath() {return newPbPath;}
+
+    public String getDiagramFilePath() {
+        return diagramFilePath;
+    }
+
+    public String getBotPbPath() {
+        return botPbPath;
+    }
+
+    public String getPbFilterPath() {
+        return pbFilterPath;
+    }
+
+    public String getPbPath() {
+        return pbPath;
+    }
+
+    public String getNewPbPath() {
+        return newPbPath;
+    }
 
     public List<GuildData> getGuildsData() {
         return guildsData;
@@ -307,6 +329,6 @@ public class DiscordBot {
     }
 
     public long getMuteTimerPeriod() {
-		return muteBanTimerPeriod;
-	}
+        return muteBanTimerPeriod;
+    }
 }

--- a/Discord-Bot/src/main/java/activitylog/ActivitySQLManager.java
+++ b/Discord-Bot/src/main/java/activitylog/ActivitySQLManager.java
@@ -1,5 +1,10 @@
 package main.java.activitylog;
 
+import main.java.files.LiteSQL;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
 /**
  * Class for creating missing tables in the activity-database on startup.
  *
@@ -8,10 +13,21 @@ package main.java.activitylog;
  */
 public class ActivitySQLManager {
 
-    public static void onCreate() {
-        LiteSQLActivity.onUpdate("CREATE TABLE IF NOT EXISTS messages(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, " +
-                "messageid INTEGER, encrypted BLOB)");
-        LiteSQLActivity.onUpdate("CREATE TABLE IF NOT EXISTS ignoredchannels(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, " +
-                "guildid INTEGER, channelids INTEGER)");
+    public static boolean onCreate() {
+        Statement stmt = LiteSQLActivity.createStatement();
+        if(stmt == null) return false;
+        try {
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS messages(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, " +
+                    "messageid INTEGER, encrypted BLOB)");
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS ignoredchannels(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, " +
+                    "guildid INTEGER, channelids INTEGER)");
+            stmt.executeBatch();
+            LiteSQL.closeStatement(stmt);
+            return true;
+        } catch (SQLException e){
+            e.printStackTrace();
+            return false;
+        }
+
     }
 }

--- a/Discord-Bot/src/main/java/activitylog/CryptoMessageHandler.java
+++ b/Discord-Bot/src/main/java/activitylog/CryptoMessageHandler.java
@@ -1,5 +1,7 @@
 package main.java.activitylog;
 
+import main.java.files.LiteSQL;
+
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -56,6 +58,7 @@ public class CryptoMessageHandler {
             prepStmt.setLong(1, messageId);
             prepStmt.setBytes(2, encrypted);
             prepStmt.executeUpdate();
+            LiteSQL.closePreparedStatement(prepStmt);
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -73,6 +76,7 @@ public class CryptoMessageHandler {
             prepStmt.setBytes(1, encrypted);
             prepStmt.setLong(2, messageId);
             prepStmt.executeUpdate();
+            LiteSQL.closePreparedStatement(prepStmt);
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -89,6 +93,7 @@ public class CryptoMessageHandler {
             assert prepStmt != null;
             prepStmt.setLong(1, messageId);
             ResultSet result = prepStmt.executeQuery();
+            LiteSQL.closePreparedStatement(prepStmt);
 
             if (result.next()) {
                 return result.getBytes("encrypted");

--- a/Discord-Bot/src/main/java/activitylog/EventAudit.java
+++ b/Discord-Bot/src/main/java/activitylog/EventAudit.java
@@ -46,11 +46,8 @@ public class EventAudit {
     }
 
     public void updateIgnoredChannels() {
-        PreparedStatement prepStmt = LiteSQLActivity.prepStmt("SELECT * FROM ignoredchannels");
         try {
-            assert prepStmt != null;
-            ResultSet result = prepStmt.executeQuery();
-
+            ResultSet result = LiteSQLActivity.onQuery("SELECT * FROM ignoredchannels");
             while (result.next()) {
                 long guildId = result.getLong("guildid");
                 String channelIds = result.getString("channelids");

--- a/Discord-Bot/src/main/java/activitylog/LiteSQLActivity.java
+++ b/Discord-Bot/src/main/java/activitylog/LiteSQLActivity.java
@@ -121,4 +121,14 @@ public class LiteSQLActivity {
             return null;
         }
     }
+
+    public static Statement createStatement(){
+        try {
+            Connection connection = POOL.getConnection();
+            return connection.createStatement();
+        } catch (SQLException e){
+            e.printStackTrace();
+            return null;
+        }
+    }
 }

--- a/Discord-Bot/src/main/java/commands/server/audit/EventAuditIgnoredChannelsCommand.java
+++ b/Discord-Bot/src/main/java/commands/server/audit/EventAuditIgnoredChannelsCommand.java
@@ -3,6 +3,7 @@ package main.java.commands.server.audit;
 import main.java.activitylog.EventAudit;
 import main.java.activitylog.LiteSQLActivity;
 import main.java.commands.server.ServerCommand;
+import main.java.files.LiteSQL;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 
@@ -37,6 +38,7 @@ public class EventAuditIgnoredChannelsCommand implements ServerCommand {
             prepStmt.setLong(1, guildId);
             prepStmt.setString(2, channelIds);
             prepStmt.executeUpdate();
+            LiteSQL.closePreparedStatement(prepStmt);
         } catch (SQLException e) {
             e.printStackTrace();
         }

--- a/Discord-Bot/src/main/java/files/LiteSQL.java
+++ b/Discord-Bot/src/main/java/files/LiteSQL.java
@@ -135,4 +135,24 @@ public class LiteSQL {
             exception.printStackTrace();
         }
     }
+
+    public static void closeStatement(Statement statement){
+        try {
+            Connection con = statement.getConnection();
+            statement.close();
+            con.close();
+        } catch (SQLException exception) {
+            exception.printStackTrace();
+        }
+    }
+
+    public static Statement createStatement(){
+        try {
+            Connection connection = POOL.getConnection();
+            return connection.createStatement();
+        } catch (SQLException e){
+            e.printStackTrace();
+            return null;
+        }
+    }
 }

--- a/Discord-Bot/src/main/java/files/LiteSQL.java
+++ b/Discord-Bot/src/main/java/files/LiteSQL.java
@@ -1,10 +1,12 @@
 package main.java.files;
 
 import main.java.DiscordBot;
+import org.apache.commons.dbcp2.BasicDataSource;
 
 import java.io.File;
 import java.io.IOException;
 import java.sql.*;
+import java.util.Collection;
 
 /**
  * Class for connecting and using the database.
@@ -15,15 +17,13 @@ import java.sql.*;
 
 public class LiteSQL {
 
-    private static Connection conn;
-    private static Statement stmt;
+    private static BasicDataSource POOL;
 
     /**
      * Connects to the database.
      */
     public static void connect() {
-        conn = null;
-
+        POOL = null;
         try {
 
             File file = new File(DiscordBot.INSTANCE.getDbFilePath());
@@ -33,19 +33,25 @@ public class LiteSQL {
             }
 
             String url = "jdbc:sqlite:" + file.getPath(); //jdbc = Java Database Connectivity
-            conn = DriverManager.getConnection(url);
+            //conn = DriverManager.getConnection(url);
 
+            POOL = new BasicDataSource();
+            POOL.setUrl(url);
             System.out.println("Verbindung zur Datenbank hergestellt.");
 
-            stmt = conn.createStatement();
-        } catch (SQLException | IOException e) {
+            //stmt = conn.createStatement();
+        } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
     public static void vacuum() {
         try {
+            Connection con = POOL.getConnection();
+            Statement stmt = con.createStatement();
             stmt.execute("VACUUM");
+            stmt.close();
+            con.close();
             System.out.println("Database VACUUM");
         } catch (SQLException e) {
             e.printStackTrace();
@@ -57,8 +63,8 @@ public class LiteSQL {
      */
     public static void disconnect() {
         try {
-            if (conn != null) {
-                conn.close();
+            if (POOL != null) {
+                POOL.close();
                 System.out.println("Verbindung zur Datenbank getrennt.");
             }
         } catch (SQLException e) {
@@ -74,7 +80,11 @@ public class LiteSQL {
     public static boolean onUpdate(String sql) {
 
         try {
+            Connection con = POOL.getConnection();
+            Statement stmt = con.createStatement();
             stmt.execute(sql);
+            stmt.close();
+            con.close();
             return true;
         } catch (SQLException e) {
             e.printStackTrace();
@@ -89,7 +99,12 @@ public class LiteSQL {
      */
     public static ResultSet onQuery(String sql) {
         try {
-            return stmt.executeQuery(sql);
+            Connection con = POOL.getConnection();
+            Statement stmt = con.createStatement();
+            ResultSet result = stmt.executeQuery(sql);
+            stmt.close();
+            con.close();
+            return result;
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -103,10 +118,21 @@ public class LiteSQL {
      */
     public static PreparedStatement prepStmt(String sql) {
         try {
-            return conn.prepareStatement(sql);
+            Connection connection = POOL.getConnection();
+            return connection.prepareStatement(sql);
         } catch (SQLException e) {
             e.printStackTrace();
             return null;
+        }
+    }
+
+    public static void closePreparedStatement(PreparedStatement statement){
+        try {
+            Connection con = statement.getConnection();
+            statement.close();
+            con.close();
+        } catch (SQLException exception) {
+            exception.printStackTrace();
         }
     }
 }

--- a/Discord-Bot/src/main/java/files/SQLManager.java
+++ b/Discord-Bot/src/main/java/files/SQLManager.java
@@ -25,5 +25,7 @@ public class SQLManager {
         LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS calldata(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, userids STRING, starttime INTEGER, endtime INTEGER, name STRING, requester INTEGER, note STRING)");
         LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS timedtasks(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, endtime INTEGER NOT NULL, type STRING NOT NULL, note STRING)");
         LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS selfroles(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, role STRING, roleid INTEGER)");
+        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS polls(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, name STRING, description STRING)");
+
     }
 }

--- a/Discord-Bot/src/main/java/files/SQLManager.java
+++ b/Discord-Bot/src/main/java/files/SQLManager.java
@@ -1,5 +1,8 @@
 package main.java.files;
 
+import java.sql.SQLException;
+import java.sql.Statement;
+
 /**
  * Class for creating missing tables in the database on startup.
  *
@@ -12,20 +15,30 @@ public class SQLManager {
     /**
      * Creates missing tables in database.
      * Should be executed on startup.
+     * @return true if successful
      */
-    public static void onCreate() {
+    public static boolean onCreate() {
 
-        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS guildroles(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, roleid INTEGER, code STRING, type STRING)");
-        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS guildchannels(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, channelid INTEGER, type STRING)");
-        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS reactroles(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, channelid INTEGER, messageid INTEGER, emote VARCHAR, roleid INTEGER)");
-        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS unbanhandlerreactions(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, channelid INTEGER, messageid INTEGER, bannedid INTEGER)");
-        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS votereactions(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, channelid INTEGER, messageid INTEGER, emotes STRING, texts STRING, value STRING, users String)");
-        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS userrecords(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, userid INTEGER, date INTEGER, endtime INTEGER, type STRING, guildid INTEGER, reason STRING, note STRING)");
-        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS invitemanager(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,guildid INTEGER, specialuserid INTEGER, verifieduserid INTEGER)");
-        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS calldata(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, userids STRING, starttime INTEGER, endtime INTEGER, name STRING, requester INTEGER, note STRING)");
-        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS timedtasks(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, endtime INTEGER NOT NULL, type STRING NOT NULL, note STRING)");
-        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS selfroles(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, role STRING, roleid INTEGER)");
-        LiteSQL.onUpdate("CREATE TABLE IF NOT EXISTS polls(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, name STRING, description STRING)");
-
+        Statement stmt = LiteSQL.createStatement();
+        if(stmt == null) return false;
+        try {
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS guildroles(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, roleid INTEGER, code STRING, type STRING)");
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS guildchannels(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, channelid INTEGER, type STRING)");
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS reactroles(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, channelid INTEGER, messageid INTEGER, emote VARCHAR, roleid INTEGER)");
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS unbanhandlerreactions(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, channelid INTEGER, messageid INTEGER, bannedid INTEGER)");
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS votereactions(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, channelid INTEGER, messageid INTEGER, emotes STRING, texts STRING, value STRING, users String)");
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS userrecords(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, userid INTEGER, date INTEGER, endtime INTEGER, type STRING, guildid INTEGER, reason STRING, note STRING)");
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS invitemanager(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,guildid INTEGER, specialuserid INTEGER, verifieduserid INTEGER)");
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS calldata(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, userids STRING, starttime INTEGER, endtime INTEGER, name STRING, requester INTEGER, note STRING)");
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS timedtasks(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, endtime INTEGER NOT NULL, type STRING NOT NULL, note STRING)");
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS selfroles(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, role STRING, roleid INTEGER)");
+            stmt.addBatch("CREATE TABLE IF NOT EXISTS polls(id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, guildid INTEGER, name STRING, description STRING)");
+            stmt.executeBatch();
+            LiteSQL.closeStatement(stmt);
+            return true;
+        } catch (SQLException exception) {
+            exception.printStackTrace();
+            return false;
+        }
     }
 }

--- a/Discord-Bot/src/main/java/files/impl/CallDatabaseSQLite.java
+++ b/Discord-Bot/src/main/java/files/impl/CallDatabaseSQLite.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.TextChannel;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -41,6 +42,7 @@ public class CallDatabaseSQLite implements CallDatabase {
             if (!result.next()) {
                 free = true;
             }
+            LiteSQL.closePreparedStatement(pstmt);
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -68,7 +70,7 @@ public class CallDatabaseSQLite implements CallDatabase {
             pstmt.setString(5, name);
             pstmt.setLong(6, requester);
             pstmt.executeUpdate();
-
+            LiteSQL.closePreparedStatement(pstmt);
             ResultSet result = LiteSQL.onQuery("SELECT id FROM calldata WHERE guildid = " + guild.getIdLong() + " AND starttime = " + startTime);
             return result.getLong("id");
         } catch (SQLException | NullPointerException e) {
@@ -108,6 +110,8 @@ public class CallDatabaseSQLite implements CallDatabase {
                 prepStmt.setString(1, search);
                 prepStmt.setLong(2, channel.getGuild().getIdLong());
                 result = prepStmt.executeQuery();
+                LiteSQL.closePreparedStatement(prepStmt);
+
 
             } catch (SQLException f) {
                 e.printStackTrace();

--- a/Discord-Bot/src/main/java/files/impl/SelfRolesSQLite.java
+++ b/Discord-Bot/src/main/java/files/impl/SelfRolesSQLite.java
@@ -21,6 +21,7 @@ public class SelfRolesSQLite implements SelfRoles {
         try {
             assert prepStmt != null;
             result = prepStmt.executeQuery();
+            LiteSQL.closePreparedStatement(prepStmt);
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -58,6 +59,7 @@ public class SelfRolesSQLite implements SelfRoles {
             prepStmt.setString(2, role.toLowerCase());
             prepStmt.setLong(3, roleId);
             prepStmt.executeUpdate();
+            LiteSQL.closePreparedStatement(prepStmt);
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -77,6 +79,7 @@ public class SelfRolesSQLite implements SelfRoles {
             prepStmt.setLong(1, guildId);
             prepStmt.setLong(2, roleId);
             prepStmt.executeUpdate();
+            LiteSQL.closePreparedStatement(prepStmt);
         } catch (SQLException e) {
             e.printStackTrace();
         }

--- a/Discord-Bot/src/main/java/files/impl/TimedTasksDatabaseSQLite.java
+++ b/Discord-Bot/src/main/java/files/impl/TimedTasksDatabaseSQLite.java
@@ -33,7 +33,9 @@ public class TimedTasksDatabaseSQLite implements TimedTasksDatabase {
             prepStmt.setLong(1, endTime);
             prepStmt.setString(2, type);
             prepStmt.setString(3, note);
-            return prepStmt.executeUpdate();
+            int result = prepStmt.executeUpdate();
+            LiteSQL.closePreparedStatement(prepStmt);
+            return result;
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -53,7 +55,9 @@ public class TimedTasksDatabaseSQLite implements TimedTasksDatabase {
         try {
             prepStmt.setLong(1, endTime);
             prepStmt.setString(2, type);
-            return prepStmt.executeUpdate();
+            int res = prepStmt.executeUpdate();
+            LiteSQL.closePreparedStatement(prepStmt);
+            return res;
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -94,7 +98,9 @@ public class TimedTasksDatabaseSQLite implements TimedTasksDatabase {
         PreparedStatement prepStmt = LiteSQL.prepStmt("DELETE FROM timedtasks WHERE type = ?");
         try {
             prepStmt.setString(1, type);
-            return prepStmt.executeUpdate();
+            int res = prepStmt.executeUpdate();
+            LiteSQL.closePreparedStatement(prepStmt);
+            return res;
         } catch (SQLException e) {
             return 0;
         }
@@ -139,6 +145,7 @@ public class TimedTasksDatabaseSQLite implements TimedTasksDatabase {
             prepStmt.setLong(1, endTime);
             prepStmt.setString(2, type);
             prepStmt.executeUpdate();
+            LiteSQL.closePreparedStatement(prepStmt);
         } catch (SQLException e) {
             e.printStackTrace();
         }

--- a/Discord-Bot/src/main/java/files/impl/UserRecordsDatabaseSQLite.java
+++ b/Discord-Bot/src/main/java/files/impl/UserRecordsDatabaseSQLite.java
@@ -28,6 +28,7 @@ public class UserRecordsDatabaseSQLite implements UserRecordsDatabase {
                 prepStmt.setString(6, reason);
                 prepStmt.setString(7, note);
                 prepStmt.executeUpdate();
+                LiteSQL.closePreparedStatement(prepStmt);
             } catch (SQLException e) {
                 e.printStackTrace();
             }
@@ -43,6 +44,7 @@ public class UserRecordsDatabaseSQLite implements UserRecordsDatabase {
                 prepStmt.setString(5, reason);
                 prepStmt.setString(6, note);
                 prepStmt.executeUpdate();
+                LiteSQL.closePreparedStatement(prepStmt);
             } catch (SQLException e) {
                 e.printStackTrace();
             }
@@ -58,6 +60,7 @@ public class UserRecordsDatabaseSQLite implements UserRecordsDatabase {
             prepStmt.setString(5, reason);
             prepStmt.setString(6, note);
             result = prepStmt.executeQuery();
+            LiteSQL.closePreparedStatement(prepStmt);
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -92,6 +95,7 @@ public class UserRecordsDatabaseSQLite implements UserRecordsDatabase {
             prepStmt.setString(1, note);
             prepStmt.setLong(2, id);
             prepStmt.executeUpdate();
+            LiteSQL.closePreparedStatement(prepStmt);
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -129,6 +133,7 @@ public class UserRecordsDatabaseSQLite implements UserRecordsDatabase {
             assert prepStmt != null;
             prepStmt.setLong(1, userId);
             ResultSet result = prepStmt.executeQuery();
+            LiteSQL.closePreparedStatement(prepStmt);
             while(result.next()) {
                 String type = result.getString("type");
                 String note = result.getString("note");
@@ -172,7 +177,7 @@ public class UserRecordsDatabaseSQLite implements UserRecordsDatabase {
             prepStmt.setLong(1, userId);
             prepStmt.setLong(2,guildId);
             ResultSet result = prepStmt.executeQuery();
-
+            LiteSQL.closePreparedStatement(prepStmt);
             if (result.next()) return true;
         } catch (SQLException e) {
             e.printStackTrace();
@@ -193,6 +198,7 @@ public class UserRecordsDatabaseSQLite implements UserRecordsDatabase {
             prepStmt.setLong(1, userId);
             prepStmt.setLong(2, guildId);
             result = prepStmt.executeQuery();
+            LiteSQL.closePreparedStatement(prepStmt);
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -226,7 +232,7 @@ public class UserRecordsDatabaseSQLite implements UserRecordsDatabase {
             prepStmt.setLong(2, guildId);
             prepStmt.setString(3, "lifted");
             ResultSet result = prepStmt.executeQuery();
-
+            LiteSQL.closePreparedStatement(prepStmt);
             while(result.next()) {
                 ids.add(result.getLong("id"));
             }
@@ -267,6 +273,7 @@ public class UserRecordsDatabaseSQLite implements UserRecordsDatabase {
             assert prepStmt != null;
             prepStmt.setLong(1, id);
             ResultSet result = prepStmt.executeQuery();
+            LiteSQL.closePreparedStatement(prepStmt);
 
             if (!result.next()) return null;
 


### PR DESCRIPTION
Hi @Asklios,
ich hab mal die Datenbank-Interfaces auf ConnectionPools umgestellt. An sich ändert sich nichts, man kann die DB-Interfaces wie immer nutzen, nur bei `prepStatement()` muss man unbedingt die Verbindung trennen! Wenn man das nicht macht geht der Thread nicht zurück in den Pool und irgendwann hat der Pool keine offenen Verbindungen mehr. Dadurch würde der Bot einfach blocken.

Ein `PreparedStatement` schließen kann man mit `LiteSQL.closePreparedStatement(prepStmt)`, eine kleine Hilfsfunktion.

An den Umfragen arbeite ich.

LG DrDeee